### PR TITLE
Adapted so that it compiles again on a recent system. Not sure if hte API changed or the compilers did.

### DIFF
--- a/src/fsoi/EyeMap
+++ b/src/fsoi/EyeMap
@@ -22,7 +22,7 @@ public:
   void setColors(osg::Vec4Array* cs);
   void setGeometry( osg::Vec3Array* verts, osg::ByteArray* fan_lengths );
 private:
-  void createDrawables();
+  void createDrawables(bool);
   osg::ref_ptr<osg::Geometry> faces;
   osg::ref_ptr<osg::Vec4Array> _colors;
   osg::ref_ptr<osg::Vec3Array> _verts;

--- a/src/fsoi/EyeMap.cpp
+++ b/src/fsoi/EyeMap.cpp
@@ -29,13 +29,16 @@ EyeMap::EyeMap( ) {
   _fan_lengths->push_back( 6 );
   _fan_lengths->push_back( 6 );
 
-  createDrawables();
+  createDrawables(true);
 }
 
-void EyeMap::createDrawables() {
+void EyeMap::createDrawables(bool isBeingConstructed=false) { //extra parameter to avoid accessing _drawables from constructor (not declared yet)
   // Remove any existing Drawables
-  _drawables.erase(_drawables.begin(), _drawables.end());
-
+  if(!isBeingConstructed){
+  //_drawables.erase(_drawables.begin(), _drawables.end());
+    this->removeDrawables(0, this->getNumDrawables());
+  }
+  
   // 1. First the faces
   faces = new osg::Geometry();
   faces->setSupportsDisplayList(false);

--- a/src/fsoi/SConstruct
+++ b/src/fsoi/SConstruct
@@ -14,7 +14,7 @@ if int(debug):
 def add_osg_opts(kws):
     if sys.platform.startswith('darwin'):
         if os.path.exists('/opt/local/include/osg'):
-            print "Using Macports's OSG version in /opt/local"
+            print("Using Macports's OSG version in /opt/local")
             env.Append(CPPPATH=['/opt/local/include/'],
                        LIBPATH=['/opt/local/lib/'], 
                        LIBS=['osg', 'OpenThreads', 'osgText', 'osgDB', 'osgUtil', 'osgGA', 'osgViewer'])

--- a/src/fsoi/fsoi_ng.cpp
+++ b/src/fsoi/fsoi_ng.cpp
@@ -724,7 +724,7 @@ FsoiErr fsoi_ng_new(FsoiObj** theobjptr, const char* filename, double scale,
   } else if (!strcmp(render_implementation,"fb")) {
     renderImplementation= osg::Camera::FRAME_BUFFER;
   } else if (!strcmp(render_implementation,"window")) {
-    renderImplementation= osg::Camera::SEPERATE_WINDOW;
+    renderImplementation= osg::Camera::SEPARATE_WINDOW;//modif from SEPERATE_WINDOW
   } else {
     fprintf(stderr,"unknown render target: %s\n",render_implementation);
     return FsoiUnknownRenderImplementeation;


### PR DESCRIPTION
- convert python 2 to 3 syntax
- EyeMap constructor did not compile because createDrawables references _drawables out of scope (not declared, API change of osg ?)
- fsoi_ng uses a parameter that has been renamed in OpenSceneGraph
Compiled on Debian docker container using python 3.9.2, scons 4.0.1, and and libopenscenegraph-dev 3.6.5 in Debian's APT repositories